### PR TITLE
Hotfix: Deno Deployでtailwindcssがビルドされない問題

### DIFF
--- a/dev.ts
+++ b/dev.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env -S deno run -A --watch=static/,routes/
 
 import dev from '$fresh/dev.ts';
+import config from '@/fresh.config.ts';
 
-await dev(import.meta.url, './main.ts');
+await dev(import.meta.url, './main.ts', config);


### PR DESCRIPTION
dev.tsで`dev`関数にconfigを渡してなかった